### PR TITLE
RAPT-111-hf - ipad-safari default-path not working

### DIFF
--- a/src/PlayersBufferManager.ts
+++ b/src/PlayersBufferManager.ts
@@ -46,10 +46,9 @@ export class PlayersBufferManager extends Dispatcher {
     // const browserVersion = this.playersFactory.playerLibrary.core.Env.major;
     // const os = this.playersFactory.playerLibrary.core.Env.os.name;
     // const osVersion = this.playersFactory.playerLibrary.core.Env.os.version;
-
     this._isAvailable = true;
     // Safari - disable;
-    if (browser === "Safari") {
+    if (browser.indexOf("Safari") > -1) {
       this._isAvailable = false;
     }
   }


### PR DESCRIPTION
https://kaltura.atlassian.net/browse/RAPT-111 

The check failed because we checked string "Safari" where the name of the browser that the player exposes is "Mobile Safari". 