### PR TITLE
RAPT-137-hf - KMS menu has 1000 z-index and now the rapt-engine is 200

### DIFF
--- a/src/Kip.scss
+++ b/src/Kip.scss
@@ -16,7 +16,7 @@
   display: none;
 }
 .kiv-rapt-engine {
-  z-index: 1000;
+  z-index: 200;
   position: absolute;
 }
 .kiv-container {


### PR DESCRIPTION
https://kaltura.atlassian.net/browse/RAPT-137

![image](https://user-images.githubusercontent.com/1536299/49388231-34b99780-f72c-11e8-9579-59270c7f74dc.png)
