### PR TITLE
fix(SUP-25413): nodes jumping doesn't always work

### DIFF
--- a/src/PlayersBufferManager.ts
+++ b/src/PlayersBufferManager.ts
@@ -507,7 +507,7 @@ export class PlayersBufferManager extends Dispatcher {
 
         // find if there is any hotspot that has a startFrom attribute
         const hotspotsWithStartFrom = hotspots.filter((hs: any) => {
-            return hs.onClick && hs.onClick.find((itm: any) => itm.payload.hasOwnProperty("startFrom"));
+            return hs.onClick && hs.onClick.find((itm: any) => typeof itm.payload.startFrom === 'number');
         });
         const arrayToCache: RaptNode[] = [];
         for (const hotSpot of hotspots) {
@@ -541,7 +541,7 @@ export class PlayersBufferManager extends Dispatcher {
             // fill startFrom attributes if they match a hotspot 
             for (const hsWithStartTime of hotspotsWithStartFrom) {
                 // find if we have a relevant start hotspot 
-                const jumpingToData = hsWithStartTime.onClick.find((itm: any) => itm.payload.hasOwnProperty("startFrom")).payload;
+                const jumpingToData = hsWithStartTime.onClick.find((itm: any) => typeof itm.payload.startFrom === 'number').payload;
                 const matchingItem = arrayToCache.find((raptNode: RaptNode) => raptNode.id === jumpingToData.destination);
                 if (matchingItem) {
                     matchingItem.startFrom = jumpingToData.startFrom;


### PR DESCRIPTION
**the issues - in this PR we are covering 2 cases:**
1.  Jumping from a node to another on a specific time
2. Jumping to a node, on time 0:0.

**Solutions:**
1. using "seekTo" instead of "startTime" - since we are removing duplicity from bufferList only by entry id- startTime is becoming meaningless in this case.
2. using typeof number for "startFrom" - in JS "0" is counted as false, we also want to allow hotspots with startTime=0 to be taken into consideration.

Solves [SUP-25413](https://kaltura.atlassian.net/browse/SUP-25413)