### PR TITLE
fix(RAPT-234): control bar is partially cut/hidden on regular and full screen

### DIFF
--- a/src/Kip.scss
+++ b/src/Kip.scss
@@ -245,7 +245,6 @@
   .playkit-player {
     .playkit-bottom-bar {
       padding: 0 8px;
-      height: 28px;
       position: absolute;
     }
     .playkit-control-button,


### PR DESCRIPTION
issue:
bottom bar is cut/hidden.

solution:
deleting fixed height of bottom bar.

Solves [RAPT-234](https://kaltura.atlassian.net/browse/RAPT-234)