### PR TITLE
fix(RAPT-235): hotspot jumps to the beginning of a video instead of a specific time

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,10 @@ This project is licensed under the AGPL-3.0 License - see the LICENSE.md file fo
         ``` 
 , this will output a tar.gz file in dist folder
 7. Go to the new tag in github and click on Edit and add the tar.gz file from dist folder
+
+
+## Deployment Instructions
+Extract the tgz files into a folder by the name of the version, in all bundle machines
+(E.G. /opt/kaltura/html5/html5lib/playkitSources/rapt/0.4.6/). The output is 2 files on that folder.
+
+Alternatively - copy the 2 files directly from the release (.js and .js.map) to the relevant folder.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaltura-interactive-player",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Kaltura Interactive player based on Rapt engine",
   "main": "index.js",
   "license": "AGPL-3.0",

--- a/src/PlayersBufferManager.ts
+++ b/src/PlayersBufferManager.ts
@@ -74,12 +74,8 @@ export class PlayersBufferManager extends Dispatcher {
                 log("log", "pbm_getPlayer", "found player in buffer list", {entryId});
                 result = bufferedItem.player;
 
-                if (result.player.currentTime > 0) {
-                    log("log", "pbm_getPlayer", "seek player to the beginning or a specific time", {
-                        entryId
-                    });
-                    result.player.currentTime = seekTo ? seekTo : 0;
-                }
+                log("log", "pbm_getPlayer", "seek player to the beginning or a specific time", {entryId});
+                result.player.currentTime = seekTo ? seekTo : 0;
                 // TODO 3 [eitan] for persistancy - assign only synced persistancy
                 if (playImmediate && !result.player.isPlaying) {
                     log("log", "pbm_getPlayer", "execute play command", {entryId});

--- a/version.ts
+++ b/version.ts
@@ -1,1 +1,1 @@
-export const VERSION:string = "0.4.6";
+export const VERSION:string = "0.4.7";


### PR DESCRIPTION
**the issue:**
when autoplay is false and jumping to the _first_ node at a specific time, from a _different_ node, the player seeks to the beginning of the first node, instead of to the specific time that was defined on the hotspot.

**the root cause:**
looking at the history of the code- back then rapt was supporting only jumping to the beginning of a video (not to mid-video)- see reference [here](https://github.com/kaltura/kaltura-interactive-player/commit/770e574f87436ef4691980c37c4e6b3bc3a48993#diff-d331eb30562fcf68dd01bf17ffc55cdc20809713099f2b17e8581eb0d5f448b7R84). when rapt started to support also jumping to mid-video, we've still kept the if block checking if currentTime > 0, see reference [here](https://github.com/kaltura/kaltura-interactive-player/commit/86887bc0538c92400790a3383f5c1f186dbaebff#diff-d331eb30562fcf68dd01bf17ffc55cdc20809713099f2b17e8581eb0d5f448b7R74).
it seems that if autoplay configuration is set to false, one of the rapt loaded players stays on currentTime=0; combining the if check, which is not relevant anymore, is causing the current issue.

**the solution:**
remove the validation on player.currentTime > 0, since it's not relevant anymore and causing the issue.

Solves RAPT-235