### PR TITLE
fix(SUP-36777): rapt player playing back automatically, though the setting for autoplay is false

### DIFF
--- a/src/Kip.ts
+++ b/src/Kip.ts
@@ -27,8 +27,7 @@ function setup(config: RaptConfig): KalturaInteractiveVideo {
   try {
     const uiconfData: any = __kalturaplayerdata.UIConf ? Object.values(__kalturaplayerdata.UIConf)[0] : __kalturaplayerdata;
     const uiconfRaptData: any = uiconfData.rapt || {};
-    const uiconfPlaybackData: any =
-      (uiconfData.player && uiconfData.player.playback) || {};
+    const uiconfPlaybackData: any = uiconfData.playback || {};
     // local config will override uiconf properties.
     config = {
       ...config,


### PR DESCRIPTION
**the issue:**
the rapt entries always start play automatically even the autoplay is false.

**the solution:**
rapt take the player playback configuration from object  uiconfData.player.playback instead of uiconfData.playback

Solves SUP-36777