### PR TITLE
fix(SUP-42014): rapt player control bar at the top

### DIFF
--- a/src/Kip.scss
+++ b/src/Kip.scss
@@ -250,7 +250,7 @@
   .playkit-player {
     .playkit-bottom-bar {
       padding: 0 8px;
-      position: absolute;
+      position: absolute !important;
     }
     .playkit-control-button,
     .playkit-control-button i {

--- a/src/Kip.scss
+++ b/src/Kip.scss
@@ -247,6 +247,7 @@
     text-shadow: 0 0 10px #ffff64;
   }
 
+  /* position need to be override from relative */
   .playkit-player {
     .playkit-bottom-bar {
       padding: 0 8px;


### PR DESCRIPTION
issue:
control bar changed place to be on top and not on bottom

solution:
change css position

resolved [SUP-42014](https://kaltura.atlassian.net/browse/SUP-42014)


[SUP-42014]: https://kaltura.atlassian.net/browse/SUP-42014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ