### PR TITLE
fix(SUP-41359): KMS DS - Media Page - Interactive video is playing even if auto play disabled

### DIFF
--- a/src/Kip.scss
+++ b/src/Kip.scss
@@ -250,7 +250,7 @@
   .playkit-player {
     .playkit-bottom-bar {
       padding: 0 8px;
-      position: absolute !important;
+      position: absolute;
     }
     .playkit-control-button,
     .playkit-control-button i {

--- a/src/Kip.scss
+++ b/src/Kip.scss
@@ -250,7 +250,7 @@
   .playkit-player {
     .playkit-bottom-bar {
       padding: 0 8px;
-      position: absolute;
+      position: absolute !important;
     }
     .playkit-control-button,
     .playkit-control-button i {

--- a/src/Kip.ts
+++ b/src/Kip.ts
@@ -25,7 +25,7 @@ function setup(config: RaptConfig): KalturaInteractiveVideo {
   // merge uiconf rapt data with current config (priority is local config) - this is a one-level object
   // extract the uiconf JSON
   try {
-    const uiconfData: any = __kalturaplayerdata.UIConf ? Object.values(__kalturaplayerdata.UIConf)[0] : __kalturaplayerdata;
+    const uiconfData: any = __kalturaplayerdata.UIConf && __kalturaplayerdata.UIConf.playback ? Object.values(__kalturaplayerdata.UIConf)[0] : __kalturaplayerdata;
     const uiconfRaptData: any = uiconfData.rapt || {};
     const uiconfPlaybackData: any =
         (uiconfData.player && uiconfData.player.playback) || uiconfData.playback || {};


### PR DESCRIPTION
**Issue:**
Rapt ignore the player configuration and use the default rapt config.

**Root cause:**
The the player data is taken from __kalturaplayerdata.UIConf even if this uiconf is not player object.

**Solution:**
Add validation that  __kalturaplayerdata.UIConf is player object by checking if playback object exist (playback object is always added on the player when creating player even if it's empty)

Solves [SUP-41359](https://kaltura.atlassian.net/browse/SUP-41359)

[SUP-41359]: https://kaltura.atlassian.net/browse/SUP-41359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ