### PR TITLE
fix(ADA-1670): [V7 RAPT player] Focus moves over hidden elements

### DIFF
--- a/src/Kip.scss
+++ b/src/Kip.scss
@@ -243,7 +243,7 @@
     padding-right: 0px;
   }
 
-  .playkit-icon-rewind-10 {
+  .playkit-control-rewind{
     display: none;
   }
 


### PR DESCRIPTION
**Issue:**
seek button is tabable even it's hidden element

**Fix:**
move the display: none on the div element and not on the button element.

solves [ADA-1670](https://kaltura.atlassian.net/browse/ADA-1670)