### PR TITLE
fix(SUP-45429): seek scrubber not available in KMS Rapt player

### DIFF
--- a/src/Kip.scss
+++ b/src/Kip.scss
@@ -196,6 +196,7 @@
     top: 13px;
     width: calc(100% - 126px);
     left: 45px;
+    z-index: 2 !important;
   }
   .hide-fullscreen .playkit-seek-bar {
     width: calc(100% - 96px);

--- a/src/Kip.scss
+++ b/src/Kip.scss
@@ -209,6 +209,10 @@
     width: calc(100% - 130px) !important;
   }
 
+  .has-captions .playkit-player .playkit-seek-bar{
+    width: calc(100% - 186px) !important;
+  }
+
   .has-timers {
 
     /* Scrubber width (when timers are on) - without audio-tracks/captions */


### PR DESCRIPTION
**Issue:** 
seekbar is not clickable 

Root cuase: 
regression from player version 3.17.25

**Fix:**
Add z-index on seek-bar element.

Solves [SUP-45429](https://kaltura.atlassian.net/browse/SUP-45429)

[SUP-45429]: https://kaltura.atlassian.net/browse/SUP-45429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ