### PR TITLE
fix(SUP-47494): [FRP2 & IRP2] Embed Path entries showing error

### DIFF
--- a/src/Kip.ts
+++ b/src/Kip.ts
@@ -44,16 +44,14 @@ function setup(config: RaptConfig): KalturaInteractiveVideo {
       }
     };
 
-    if (serviceUrl) {
+    if (serviceUrl && !config.provider?.env?.serviceUrl) {
       if (!config.provider) {
         config.provider = {};
       }
       if (!config.provider.env) {
         config.provider.env = {};
       }
-      if(!config.provider.env.serviceUrl) {
-        config.provider.env.serviceUrl = serviceUrl;
-      }
+      config.provider.env.serviceUrl = serviceUrl;
     }
 
     // detect Google Analytics


### PR DESCRIPTION
issue:
on frp and irp when embed path video it has an error

root cause:
serviceurl was fro nvq by default and it check if there is other serviceUrl in provider but it never set it in the config

solution:
get the parameter from the uiconfdata and add it to the config

solved [SUP-47494](https://kaltura.atlassian.net/browse/SUP-47494)

[SUP-47494]: https://kaltura.atlassian.net/browse/SUP-47494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ