### PR TITLE
fix(SUP-49327): [Novartis] Multiple rapt media embedded in single page issue

### DIFF
--- a/src/PlayersManager.ts
+++ b/src/PlayersManager.ts
@@ -368,7 +368,7 @@ export class PlayersManager extends Dispatcher {
     }, 269);
     const newEntryId = media.sources[0].src;
     const nextRaptNode: RaptNode = media.node;
-    const raptLayer: HTMLElement = document.querySelector(" .kiv-rapt-engine");
+    const raptLayer: HTMLElement = this.domManager.getContainer().querySelector(" .kiv-rapt-engine");
 
     // send analytics of nodePlay - event44
     if (this.analyticsModel) {


### PR DESCRIPTION
****Issue:****
When embedding two rapt player in one single page clicking on hotspots on second player cause the hotspots on the first player to disappear.

**Root Cause:** 
we are selecting the kiv-rapt-engine element directly from the dom so we always get the element from first player 
(first element in the dom with this class) and not from relevant player.

**Solution:**
Select the kiv-rapt-engine from the current rapt player 