### PR TITLE
fix(SUP-51195): Caption Language Selector on RAPT

### DIFF
--- a/src/Kip.scss
+++ b/src/Kip.scss
@@ -159,10 +159,12 @@
     display: inline-block;
   }
 
-  .playkit-player .playkit-right-controls .playkit-control-button-container.playkit-control-settings .playkit-smart-container .playkit-smart-container-item:last-child
-  {
+  .playkit-player .playkit-right-controls .playkit-control-button-container.playkit-control-settings .playkit-smart-container .playkit-smart-container-item:has(#speed) {
+
     display: none;
   }
+
+
 
 
   &.rapt-switching{


### PR DESCRIPTION
issue:
captions menu not show in rapt videos

root cause: 
changes that made in player version 3.17.64 change the html order of the elements, and style in rapt remove the last element cause that captions is removed by style

fix:
on css remove only the element that have speed on it. (base on the commit the css was added this was the request to remove speed)

solve [sup-51195](https://kaltura.atlassian.net/browse/SUP-51195)