### PR TITLE
fix(SUP-51390): Path buttons overlay player controls

### DIFF
--- a/src/Kip.scss
+++ b/src/Kip.scss
@@ -24,7 +24,7 @@
 }
 
 .kiv-rapt-engine {
-  z-index: 7;
+  z-index: 1;
   position: absolute;
   html,
   body,


### PR DESCRIPTION
issue:
when put rapt buttons on the bottom of the player, the buttons are above the player ui

solution:
downgrade z-index for rapt so the player ui will be on top

solve [sup-51390](https://kaltura.atlassian.net/browse/SUP-51390)