### PR TITLE
fix(SUP-51390): Path buttons overlay player controls

### DIFF
--- a/src/Kip.scss
+++ b/src/Kip.scss
@@ -24,7 +24,7 @@
 }
 
 .kiv-rapt-engine {
-  z-index: 7;
+  z-index: 1;
   position: absolute;
   html,
   body,

--- a/src/Kip.scss
+++ b/src/Kip.scss
@@ -2,9 +2,6 @@
   border-radius: 4px;
   background: #eeeeee;
 }
-.kiv-player.current-playing {
-  z-index: 6;
-}
 
 .kiv-initiated {
   .playkit-pre-playback-play-overlay {


### PR DESCRIPTION
issue:
when put rapt buttons on the bottom of the player, the buttons are above the player ui

solution:
fix z-index values

solve [sup-51390](https://kaltura.atlassian.net/browse/SUP-51390)